### PR TITLE
No Duplicate Repository Imports

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -8,7 +8,16 @@ service cloud.firestore {
 
     match /crt_repositories/{repository} {
         allow read: if (request.auth.uid in request.resource.data.reviewers) || (request.auth.uid == request.resource.data.user);
-        allow write: if request.auth.uid == request.resource.data.user;
+        allow write: if request.auth.uid == request.resource.data.user && hasUniqueFieldValue(database, "crt_repositories", request, "hash");
     }
+
+    match /z_UNIQUE_CONSTRAINTS/{collection}/{field}/{value} {
+        allow read: if true;
+        allow write: if get(/databases/$(database)/documents/$(collection)/$(request.resource.data.for_document)).data.user == request.auth.uid;
+    }
+  }
+
+  function hasUniqueFieldValue(database, collection, request, field) {
+    return !exists(/databases/$(database)/documents/z_UNIQUE_CONSTRAINTS/$(collection)/$(field)/$(request.resource.data[field]));
   }
 }

--- a/hosting/src/components/pages/ImportRepositoryPage.tsx
+++ b/hosting/src/components/pages/ImportRepositoryPage.tsx
@@ -66,7 +66,8 @@ export function ImportRepositoryPage() {
 				branch: branch.name,
 				commit: branch.commit.sha,
 				user: user.uid,
-				reviewers: []
+				reviewers: [],
+				hash: `${repo.id}:${branch.commit.sha}`
 			});
 		} catch (error) {
 			console.error(error);

--- a/hosting/src/models/GitRepositoryModel.ts
+++ b/hosting/src/models/GitRepositoryModel.ts
@@ -10,4 +10,6 @@ export class GitRepositoryModel extends BaseModel {
 	user!: string;
 
 	reviewers!: string[];
+
+	hash!: string;
 }

--- a/hosting/src/repositories/BaseRepository.ts
+++ b/hosting/src/repositories/BaseRepository.ts
@@ -1,13 +1,32 @@
-import { doc, getDoc, setDoc, addDoc, getFirestore, collection, type DocumentData} from "firebase/firestore";
+import {
+	doc,
+	getDoc,
+	setDoc,
+	addDoc,
+	getFirestore,
+	collection,
+	type DocumentData,
+	serverTimestamp
+} from "firebase/firestore";
 import { app } from "../firebase";
 import { BaseModel } from "../models/BaseModel";
 
 export abstract class BaseRepository<T extends BaseModel> {
+	private static readonly UNIQUE_FIELD_COLLECTION = "z_UNIQUE_CONSTRAINTS";
 	private readonly firestore = getFirestore(app);
 
 	protected constructor(
 		protected readonly collection: string
 	) {}
+
+	protected async createUniqueField(documentId: string, field: string, value: string): Promise<void> {
+		const ref = doc(this.firestore, BaseRepository.UNIQUE_FIELD_COLLECTION, this.collection, field, value);
+
+		return setDoc(ref, {
+			created: serverTimestamp(),
+			for_document: documentId
+		});
+	}
 
 	async getById(id: string): Promise<DocumentData | undefined> {
 		const ref = doc(this.firestore, this.collection, id);

--- a/hosting/src/repositories/GitRepositoryRepository.ts
+++ b/hosting/src/repositories/GitRepositoryRepository.ts
@@ -5,6 +5,14 @@ export class GitRepositoryRepository extends BaseRepository<GitRepositoryModel> 
 	constructor() {
 		super("crt_repositories");
 	}
+
+	async create(data: GitRepositoryModel): Promise<string> {
+		const documentId = await super.create(data);
+
+		await this.createUniqueField(documentId, "hash", data.hash);
+
+		return documentId;
+	}
 }
 
 export const gitRepositoryRepository = new GitRepositoryRepository();


### PR DESCRIPTION
We do not want people to be able to import the same repository repeatedly, as we would be storing useless data. This introduces:
- A mechanism for adding unique field constraints to Cloud Firestore, because it does not support it natively
- A requirement of `hash` to be unique on documents within the `crt_repositories` collection